### PR TITLE
pom.xml adjustments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,40 @@
 				</configuration>
 			</plugin> 
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <groupId>${project.groupId}</groupId>
+                            <version>${project.version}</version>
+                            <file>${project.build.directory}/${project.artifactId}-${project.version}.jar</file>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin> 
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
@@ -59,7 +93,7 @@
 						</connector>
 					</connectors>
 					<contextPath>http_proxy</contextPath>
-					<webAppSourceDirectory>${project.build.directory}/http_proxy-1.0-SNAPSHOT</webAppSourceDirectory>
+					<webAppSourceDirectory>${project.build.directory}/${project.artifactId}-${project.version}</webAppSourceDirectory>
 				</configuration>
 			</plugin>
 			
@@ -112,16 +146,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.3</version>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>servlet-api-2.5</artifactId>
+			<version>6.1.14</version>
 		</dependency>
 
 		<!-- Mortbay dependencies -->
 		<dependency>
 			<groupId>org.mortbay.jetty</groupId>
 			<artifactId>jetty</artifactId>
-			<version>6.1.19</version>
+			<version>6.1.14</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
We want to run http-proxy not as a stand-alone war, but as a lib inside nfms-portal.
Thus we have made some changes to pom.xml:
1. Enable jar file generation on "mvn install" (along with the former war one).
2. Adapt servlet api dependency to the one coming from jetty. This is needed to run jetty inside eclipse with no conflicts (and yes, jetty has to be 6.1.14...).
3. Corrected the webApp directory name to run "mvn jetty:run" from commandline with no errors.
