### PR TITLE
Updated commons-codec to 1.4 (same version used by GeoStore) so that …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.1</version>
 		</dependency>
+        
+        <dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.4</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
…the build in MapStore2 does not include two different versions