### PR TITLE
Use Java 21 to build and run proxy,  add a main entrypoint and a docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '21'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B clean install
@@ -36,9 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'adopt'
           server-id: geosolutions
           server-username: MAVEN_USERNAME

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 */target/*
 target/
 .idea/
+main/assembly/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 */target/*
 target/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# --- Build stage ---
+FROM eclipse-temurin:21-jdk-alpine AS build
+
+RUN apk add --no-cache maven
+
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+COPY src ./src
+RUN mvn clean package -Pdocker -DskipTests -B
+
+# --- Runtime stage ---
+FROM gcr.io/distroless/java21-debian12
+
+COPY --from=build /app/target/http-proxy.jar /app/http-proxy.jar
+
+ENV PORT=8080
+EXPOSE 8080
+
+USER nonroot:nonroot
+ENTRYPOINT ["java", "-jar", "/app/http-proxy.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -116,23 +116,6 @@
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.19</version>
-				<configuration>
-					<contextPath>http_proxy</contextPath>
-					<connectors>
-						<connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-							<port>8080</port>
-							<maxIdleTime>10000</maxIdleTime>
-						</connector>
-					</connectors>
-					<contextPath>http_proxy</contextPath>
-					<webAppSourceDirectory>${project.build.directory}/${project.artifactId}-${project.version}</webAppSourceDirectory>
-				</configuration>
-			</plugin>
-
 			<!-- versioning -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -328,6 +311,50 @@
 		</dependency>
 
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>docker</id>
+			<dependencies>
+				<dependency>
+					<groupId>jakarta.servlet</groupId>
+					<artifactId>jakarta.servlet-api</artifactId>
+					<version>6.1.0</version>
+					<scope>compile</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.7.1</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>it.geosolutions.httpproxy.Main</mainClass>
+								</manifest>
+							</archive>
+							<descriptors>
+								<descriptor>src/main/assembly/fat-jar.xml</descriptor>
+							</descriptors>
+							<finalName>http-proxy</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-assembly</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.eclipse.jetty.ee11</groupId>
+				<artifactId>jetty-ee11-maven-plugin</artifactId>
+				<version>12.1.9</version>
+			</plugin>
+
 			<!-- versioning -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,17 +27,17 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.13.0</version>
 				<configuration>
-					<source>8</source>
-					<target>8</target>
+					<source>21</source>
+					<target>21</target>
 				</configuration>
 			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>3.5.2</version>
 				<configuration>
 					<skip>false</skip>
 				</configuration>
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <id>make-a-jar</id>
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>3.1.3</version>
                 <executions>
                     <execution>
                         <phase>install</phase>
@@ -82,7 +82,7 @@
             <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.1.3</version>
 				<executions>
 					<execution>
 						<phase>deploy</phase>
@@ -107,7 +107,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.4.0</version>
 				<configuration>
 					<webXml>
 						${basedir}/src/main/webapp/WEB-INF/web.xml
@@ -137,7 +137,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.2.2</version>
+				<version>3.1.1</version>
 				<configuration>
 				  <tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
@@ -155,8 +155,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<log4j-version>2.19.0</log4j-version>
-		<http-client-version>4.5.13</http-client-version>
+		<log4j-version>2.25.4</log4j-version>
+		<http-client-version>4.5.14</http-client-version>
+		<jetty-version>12.1.8</jetty-version>
 	</properties>
 
 	<dependencyManagement>
@@ -173,19 +174,19 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-slf4j-impl</artifactId>
+				<artifactId>log4j-slf4j2-impl</artifactId>
 				<version>${log4j-version}</version>
 			</dependency>
 			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>5.11.4</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>1.5</version>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+				<version>2.0.0-M5</version>
 			</dependency>
 
 			<dependency>
@@ -203,58 +204,56 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.1</version>
+				<version>2.18.0</version>
 			</dependency>
 
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.4</version>
+				<version>1.17.1</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>servlet-api-2.5</artifactId>
-				<version>6.1.14</version>
-			</dependency>
-
-			<!-- Mortbay dependencies -->
-			<dependency>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>jetty</artifactId>
-				<version>6.1.23</version>
-				<scope>test</scope>
+				<groupId>jakarta.servlet</groupId>
+				<artifactId>jakarta.servlet-api</artifactId>
+				<version>6.1.0</version>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>jetty-servlet-tester</artifactId>
-				<version>6.1.5</version>
+				<groupId>org.eclipse.jetty.ee10</groupId>
+				<artifactId>jetty-ee10-webapp</artifactId>
+				<version>${jetty-version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>5.14.2</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.mockito</groupId>
-				<artifactId>mockito-all</artifactId>
-				<version>1.9.5</version>
+				<artifactId>mockito-junit-jupiter</artifactId>
+				<version>5.14.2</version>
 				<scope>test</scope>
 			</dependency>
 
-
 			<dependency>
-				<groupId>com.github.tomakehurst</groupId>
-				<artifactId>wiremock-jre8-standalone</artifactId>
-				<version>2.32.0</version>
+				<groupId>org.wiremock</groupId>
+				<artifactId>wiremock-standalone</artifactId>
+				<version>3.10.0</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
 	<dependencies>
-		<!-- JUnit dependencies -->
+		<!-- JUnit 5 dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -269,13 +268,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
 		</dependency>
 
 		<!-- Commons -->
 		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
 		</dependency>
 
 		<dependency>
@@ -299,33 +298,32 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>servlet-api-2.5</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 		</dependency>
 
-		<!-- Mortbay dependencies -->
+		<!-- Embedded Jetty -->
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty</artifactId>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-webapp</artifactId>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-        <dependency>
-        	<groupId>org.mortbay.jetty</groupId>
-        	<artifactId>jetty-servlet-tester</artifactId>
-        	<scope>test</scope>
-        </dependency>
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8-standalone</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock-standalone</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/assembly/fat-jar.xml
+++ b/src/main/assembly/fat-jar.xml
@@ -1,0 +1,23 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>fat-jar</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.outputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <unpack>true</unpack>
+            <useProjectArtifact>false</useProjectArtifact>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/it/geosolutions/httpproxy/HTTPProxy.java
+++ b/src/main/java/it/geosolutions/httpproxy/HTTPProxy.java
@@ -33,24 +33,22 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.StringTokenizer;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -67,7 +65,6 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.ContentBody;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
 import org.slf4j.LoggerFactory;
@@ -232,7 +229,7 @@ public class HTTPProxy extends HttpServlet {
         };
     }
 
-    private Boolean isNonProxyHost(String host) {
+    private boolean isNonProxyHost(String host) {
         boolean isNonProxyHost = false;
         String nonProxyHostProp = System.getProperty("http.nonProxyHosts");
         if (nonProxyHostProp != null) {
@@ -243,9 +240,8 @@ public class HTTPProxy extends HttpServlet {
                 nonProxyHostProp = nonProxyHostProp.substring(0, nonProxyHostProp.length() - 1);
             }
             LOGGER.info("http.nonProxyHosts value: " + nonProxyHostProp);
-            StringTokenizer tokenizer = new StringTokenizer(nonProxyHostProp, "|");
-            while (tokenizer.hasMoreTokens()) {
-                String str = tokenizer.nextToken().trim();
+            for (String token : nonProxyHostProp.split("\\|")) {
+                String str = token.trim();
                 str = str.replace("*", "[\\w-]*");
                 Pattern pattern = Pattern.compile(str);
                 Matcher matcher = pattern.matcher(host);
@@ -304,12 +300,11 @@ public class HTTPProxy extends HttpServlet {
             URL url = null;
             String user = null, password = null;
 
-            Set<?> entrySet = httpServletRequest.getParameterMap().entrySet();
+            Set<Map.Entry<String, String[]>> entrySet = httpServletRequest.getParameterMap().entrySet();
 
-            for (Object anEntrySet : entrySet) {
-                Map.Entry header = (Map.Entry) anEntrySet;
-                String key = (String) header.getKey();
-                String value = ((String[]) header.getValue())[0];
+            for (Map.Entry<String, String[]> header : entrySet) {
+                String key = header.getKey();
+                String value = header.getValue()[0];
 
                 if ("user".equals(key)) {
                     user = value;
@@ -405,7 +400,7 @@ public class HTTPProxy extends HttpServlet {
                 // Check if this is a mulitpart (file upload) POST
                 // //////////////////////////////////////////////////
 
-                if (ServletFileUpload.isMultipartContent(httpServletRequest)) {
+                if (JakartaServletFileUpload.isMultipartContent(httpServletRequest)) {
                     this.handleMultipart(postMethodProxyRequest, httpServletRequest);
                 } else {
                     this.handleStandard(postMethodProxyRequest, httpServletRequest);
@@ -479,7 +474,7 @@ public class HTTPProxy extends HttpServlet {
                 // Check if this is a mulitpart (file upload) PUT
                 // //////////////////////////////////////////////////
 
-                if (ServletFileUpload.isMultipartContent(httpServletRequest)) {
+                if (JakartaServletFileUpload.isMultipartContent(httpServletRequest)) {
                     this.handleMultipart(putMethodProxyRequest, httpServletRequest);
                 } else {
                     this.handleStandard(putMethodProxyRequest, httpServletRequest);
@@ -568,28 +563,25 @@ public class HTTPProxy extends HttpServlet {
      *
      * @param postMethodProxyRequest The {@link PostMethod} that we are configuring to send a multipart POST request
      * @param httpServletRequest     The {@link HttpServletRequest} that contains the mutlipart POST data to be sent via the {@link PostMethod}
+     * @throws IOException 
      */
     private void handleMultipart(HttpRequestBase methodProxyRequest,
-                                 HttpServletRequest httpServletRequest) throws ServletException {
+                                 HttpServletRequest httpServletRequest) throws ServletException, IOException {
 
         // ////////////////////////////////////////////
         // Create a factory for disk-based file items
         // ////////////////////////////////////////////
 
-        DiskFileItemFactory diskFileItemFactory = new DiskFileItemFactory();
-
-        // /////////////////////////////
-        // Set factory constraints
-        // /////////////////////////////
-
-        diskFileItemFactory.setSizeThreshold(this.getMaxFileUploadSize());
-        diskFileItemFactory.setRepository(Utils.DEFAULT_FILE_UPLOAD_TEMP_DIRECTORY);
+        DiskFileItemFactory diskFileItemFactory = DiskFileItemFactory.builder()
+                .setBufferSize(this.getMaxFileUploadSize())
+                .setPath(Utils.DEFAULT_FILE_UPLOAD_TEMP_DIRECTORY.toPath())
+                .get();
 
         // //////////////////////////////////
         // Create a new file upload handler
         // //////////////////////////////////
 
-        ServletFileUpload servletFileUpload = new ServletFileUpload(diskFileItemFactory);
+        JakartaServletFileUpload servletFileUpload = new JakartaServletFileUpload(diskFileItemFactory);
 
         // //////////////////////////
         // Parse the request
@@ -601,7 +593,7 @@ public class HTTPProxy extends HttpServlet {
             // Get the multipart items as a list
             // /////////////////////////////////////
 
-            List<FileItem> listFileItems = (List<FileItem>) servletFileUpload
+            List<FileItem> listFileItems = servletFileUpload
                     .parseRequest(httpServletRequest);
 
             // /////////////////////////////////////////
@@ -692,8 +684,6 @@ public class HTTPProxy extends HttpServlet {
             httpClient = null;
             httpClient = createHttpClient();
         }
-
-        InputStream inputStreamServerResponse = null;
 
         try {
 
@@ -788,29 +778,21 @@ public class HTTPProxy extends HttpServlet {
             // Send the content to the client
             // ///////////////////////////////////
 
-            inputStreamServerResponse = response.getEntity().getContent();
+            try (InputStream inputStreamServerResponse = response.getEntity().getContent()) {
+                if (inputStreamServerResponse != null) {
+                    byte[] b = new byte[proxyConfig.getDefaultStreamByteSize()];
 
-            if (inputStreamServerResponse != null) {
-                byte[] b = new byte[proxyConfig.getDefaultStreamByteSize()];
-
-                int read = 0;
-                ServletOutputStream out = httpServletResponse.getOutputStream();
-                while ((read = inputStreamServerResponse.read(b)) > 0) {
-                    out.write(b, 0, read);
+                    int read;
+                    ServletOutputStream out = httpServletResponse.getOutputStream();
+                    while ((read = inputStreamServerResponse.read(b)) > 0) {
+                        out.write(b, 0, read);
+                    }
                 }
             }
 
         } catch (Exception e) {
             LOGGER.error("Error executing HTTP method", e);
         } finally {
-            try {
-                if (inputStreamServerResponse != null)
-                    inputStreamServerResponse.close();
-            } catch (IOException e) {
-                LOGGER.error("Error closing request input stream", e);
-                throw new ServletException(e.getMessage());
-            }
-
             httpMethodProxyRequest.releaseConnection();
         }
     }
@@ -831,7 +813,6 @@ public class HTTPProxy extends HttpServlet {
      * @param httpMethodProxyRequest The request that we are about to send to the proxy host
      * @return ProxyInfo
      */
-    @SuppressWarnings("rawtypes")
     private ProxyInfo setProxyRequestHeaders(URL url, HttpServletRequest httpServletRequest,
                                              HttpRequestBase httpMethodProxyRequest) {
 
@@ -845,7 +826,7 @@ public class HTTPProxy extends HttpServlet {
         // names sent by the client.
         // ////////////////////////////////////////
 
-        Enumeration enumerationOfHeaderNames = httpServletRequest.getHeaderNames();
+        Enumeration<String> enumerationOfHeaderNames = httpServletRequest.getHeaderNames();
 
         // ////////////////////////////////////////
         // Load header whitelist/blacklist for
@@ -856,7 +837,7 @@ public class HTTPProxy extends HttpServlet {
         Set<String> headerBlacklist = proxyConfig.getRequestHeaderBlacklist();
 
         while (enumerationOfHeaderNames.hasMoreElements()) {
-            String stringHeaderName = (String) enumerationOfHeaderNames.nextElement();
+            String stringHeaderName = enumerationOfHeaderNames.nextElement();
 
             if (stringHeaderName.equalsIgnoreCase(Utils.CONTENT_LENGTH_HEADER_NAME))
                 continue;
@@ -890,10 +871,10 @@ public class HTTPProxy extends HttpServlet {
             // Thus, we get an Enumeration of the header values sent by the client
             // ////////////////////////////////////////////////////////////////////////
 
-            Enumeration enumerationOfHeaderValues = httpServletRequest.getHeaders(stringHeaderName);
+            Enumeration<String> enumerationOfHeaderValues = httpServletRequest.getHeaders(stringHeaderName);
 
             while (enumerationOfHeaderValues.hasMoreElements()) {
-                String stringHeaderValue = (String) enumerationOfHeaderValues.nextElement();
+                String stringHeaderValue = enumerationOfHeaderValues.nextElement();
 
                 // ////////////////////////////////////////////////////////////////
                 // In case the proxy host is running multiple virtual servers,

--- a/src/main/java/it/geosolutions/httpproxy/HostChecker.java
+++ b/src/main/java/it/geosolutions/httpproxy/HostChecker.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpRequestBase;
 

--- a/src/main/java/it/geosolutions/httpproxy/HostNameChecker.java
+++ b/src/main/java/it/geosolutions/httpproxy/HostNameChecker.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpRequestBase;
 

--- a/src/main/java/it/geosolutions/httpproxy/Main.java
+++ b/src/main/java/it/geosolutions/httpproxy/Main.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2007 - 2011 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.httpproxy;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Main entry point for running the HTTP Proxy with embedded Jetty.
+ * Used for standalone deployment (fat JAR / Docker).
+ */
+public class Main {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+
+    public static void main(String[] args) throws Exception {
+        int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
+
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(port);
+        server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+
+        // Set the proxyPropPath init parameter
+        String proxyPropPath = System.getenv().getOrDefault("PROXY_PROP_PATH", "/proxy.properties");
+        context.setInitParameter("proxyPropPath", proxyPropPath);
+
+        // Register the proxy servlet
+        context.addServlet(new ServletHolder(new HTTPProxy()), "/proxy/*");
+
+        server.setHandler(context);
+        server.start();
+        LOGGER.info("HTTP Proxy started on port {}", port);
+        server.join();
+    }
+}

--- a/src/main/java/it/geosolutions/httpproxy/MethodsChecker.java
+++ b/src/main/java/it/geosolutions/httpproxy/MethodsChecker.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpRequestBase;
 

--- a/src/main/java/it/geosolutions/httpproxy/MimeTypeChecker.java
+++ b/src/main/java/it/geosolutions/httpproxy/MimeTypeChecker.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpRequestBase;

--- a/src/main/java/it/geosolutions/httpproxy/ProxyCallback.java
+++ b/src/main/java/it/geosolutions/httpproxy/ProxyCallback.java
@@ -22,8 +22,8 @@ package it.geosolutions.httpproxy;
 import java.io.IOException;
 import java.net.URL;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpRequestBase;
 

--- a/src/main/java/it/geosolutions/httpproxy/ProxyConfig.java
+++ b/src/main/java/it/geosolutions/httpproxy/ProxyConfig.java
@@ -26,10 +26,11 @@ import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ProxyConfig class to define the proxy configuration.
@@ -38,7 +39,7 @@ import javax.servlet.ServletContext;
  */
 final class ProxyConfig {
 
-    private final static Logger LOGGER = Logger.getLogger(ProxyConfig.class.toString());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfig.class);
 
     /**
      * A list of regular expressions describing hostnames the proxy is permitted to forward to
@@ -215,9 +216,7 @@ final class ProxyConfig {
                         : this.defaultMaxConnectionsPerHost);
 
             } catch (NumberFormatException e) {
-                if (LOGGER.isLoggable(Level.SEVERE))
-                    LOGGER.log(Level.SEVERE,
-                            "Error parsing the proxy properties file using default", e);
+                LOGGER.error("Error parsing proxy configuration: {}", e.getMessage(), e);
 
                 this.setSoTimeout(this.soTimeout);
                 this.setConnectionTimeout(this.connectionTimeout);
@@ -248,25 +247,16 @@ final class ProxyConfig {
             try {
                 inputStream = new FileInputStream(path);
             } catch (FileNotFoundException e) {
-                if (LOGGER.isLoggable(Level.WARNING))
-                    LOGGER.log(Level.WARNING, "The properties file " + path + " cannot be found");
+                LOGGER.warn("The properties file {} cannot be found", path);
             }
         }
         if (inputStream != null) {
-            Properties props = new Properties();
-            try {
-                props.load(inputStream);
+            try (InputStream is = inputStream) {
+                Properties props = new Properties();
+                props.load(is);
                 properties.putAll(props);
             } catch (IOException e) {
-                if (LOGGER.isLoggable(Level.SEVERE))
-                    LOGGER.log(Level.SEVERE, "Error loading the proxy properties file from " + path, e);
-            } finally {
-                if (inputStream != null)
-                    try {
-                        inputStream.close();
-                    } catch (IOException e) {
-                        
-                    }
+                LOGGER.error("Error loading the proxy properties file from {}", path, e);
             }
         }
     }

--- a/src/main/java/it/geosolutions/httpproxy/RequestTypeChecker.java
+++ b/src/main/java/it/geosolutions/httpproxy/RequestTypeChecker.java
@@ -26,8 +26,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.HttpRequestBase;
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app id="WebApp_ID" version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+<web-app id="WebApp_ID" version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 	
 	<display-name>HTTP_PROXY</display-name>
 

--- a/src/test/java/it/geosolutions/httpproxy/HttpProxyIntegrationTests.java
+++ b/src/test/java/it/geosolutions/httpproxy/HttpProxyIntegrationTests.java
@@ -97,12 +97,12 @@ public class HttpProxyIntegrationTests {
     public void testGETUsingWireMock() throws IOException {
 
         wireMockRule.stubFor(
-                get(urlEqualTo("/geostore/users"))
-                        .willReturn(
-                                aResponse()
-                                        .withStatus(200)
-                                        .withHeader("Content-Type", "text/xml")
-                                        .withBody("<response>Some content</response>")));
+            get(urlEqualTo("/geostore/users"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "text/xml")
+                    .withBody("<response>Some content</response>")));
 
         String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/users";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
@@ -189,13 +189,13 @@ public class HttpProxyIntegrationTests {
 
         String requestBody = "<user><userId>5</userId><userName>John Doe</userName></user>";
         wireMockRule.stubFor(
-                put(urlEqualTo("/geostore/users/5"))
-                        .withRequestBody(equalToXml(requestBody))
-                        .willReturn(
-                                aResponse()
-                                        .withStatus(200)
-                                        .withHeader("Content-Type", "text/xml")
-                                        .withBody("<response>5</response>")));
+            put(urlEqualTo("/geostore/users/5"))
+               .withRequestBody(equalToXml(requestBody))
+               .willReturn(
+                   aResponse()
+                       .withStatus(200)
+                       .withHeader("Content-Type", "text/xml")
+                       .withBody("<response>5</response>")));
 
         String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/users/5";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
@@ -221,10 +221,10 @@ public class HttpProxyIntegrationTests {
         System.setProperty("http.proxyPort", "");
 
         wireMockRule.stubFor(
-                get(urlEqualTo("/geostore/resources"))
-                        .willReturn(
-                                aResponse()
-                                        .withStatus(200)));
+            get(urlEqualTo("/geostore/resources"))
+                .willReturn(
+                    aResponse()
+                      .withStatus(200)));
 
         String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/resources";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;

--- a/src/test/java/it/geosolutions/httpproxy/HttpProxyIntegrationTests.java
+++ b/src/test/java/it/geosolutions/httpproxy/HttpProxyIntegrationTests.java
@@ -2,7 +2,10 @@ package it.geosolutions.httpproxy;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -10,12 +13,8 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.*;
-import org.mortbay.jetty.Connector;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.webapp.WebAppContext;
-import org.mortbay.thread.BoundedThreadPool;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -30,13 +29,15 @@ public class HttpProxyIntegrationTests {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(HttpProxyIntegrationTests.class);
 
-    @Rule
-    public WireMockRule wireMockRule =
-            new WireMockRule(WireMockConfiguration.options().dynamicPort());
+    @RegisterExtension
+    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
+            .options(WireMockConfiguration.options().dynamicPort())
+            .build();
 
-    @Rule
-    public WireMockRule wireMockRule1 =
-            new WireMockRule(WireMockConfiguration.options().dynamicPort());
+    @RegisterExtension
+    static WireMockExtension wireMockRule1 = WireMockExtension.newInstance()
+            .options(WireMockConfiguration.options().dynamicPort())
+            .build();
 
     static WireMockServer wireMockServer;
 
@@ -45,7 +46,7 @@ public class HttpProxyIntegrationTests {
     private static String proxyHost;
     private static String proxyPort;
 
-    @BeforeClass
+    @BeforeAll
     public static void startHttpProxyServer() {
 
         try {
@@ -56,23 +57,15 @@ public class HttpProxyIntegrationTests {
             wireMockServer.start();
 
             jettyServer = new Server();
+            ServerConnector connector = new ServerConnector(jettyServer);
+            connector.setPort(8080);
+            jettyServer.addConnector(connector);
 
-            BoundedThreadPool tp = new BoundedThreadPool();
-            tp.setMaxThreads(50);
-
-            SocketConnector conn = new SocketConnector();
-            int port = 8080;
-
-            conn.setPort(port);
-            conn.setThreadPool(tp);
-            conn.setAcceptQueueSize(100);
-            jettyServer.setConnectors(new Connector[]{conn});
-
-            WebAppContext wah = new WebAppContext();
-            wah.setContextPath("/http_proxy");
-            wah.setWar("src/main/webapp");
-            jettyServer.setHandler(wah);
-            wah.setTempDirectory(new File("target/work"));
+            WebAppContext webapp = new WebAppContext();
+            webapp.setContextPath("/http_proxy");
+            webapp.setWar(new File("src/main/webapp").getAbsolutePath());
+            webapp.setTempDirectory(new File("target/work"));
+            jettyServer.setHandler(webapp);
 
             jettyServer.start();
 
@@ -103,21 +96,20 @@ public class HttpProxyIntegrationTests {
     @Test
     public void testGETUsingWireMock() throws IOException {
 
-        wireMockRule.addStubMapping(
-                stubFor(
-                        get(urlEqualTo("/geostore/users"))
-                                .willReturn(
-                                        aResponse()
-                                                .withStatus(200)
-                                                .withHeader("Content-Type", "text/xml")
-                                                .withBody("<response>Some content</response>"))));
+        wireMockRule.stubFor(
+                get(urlEqualTo("/geostore/users"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "text/xml")
+                                        .withBody("<response>Some content</response>")));
 
-        String url = "http://localhost:" + wireMockRule.port() + "/geostore/users";
+        String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/users";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
         HttpGet httpGet = new HttpGet(proxyURL);
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpResponse httpResponse = httpClient.execute(httpGet);
-            Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+            Assertions.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
             wireMockRule.verify(getRequestedFor(urlEqualTo("/geostore/users")));
         }
     }
@@ -129,17 +121,16 @@ public class HttpProxyIntegrationTests {
     public void testPOSTUsingWireMockXML() throws IOException {
 
         String requestBody = "<user><userId>5</userId><userName>Jane Doe</userName></user>";
-        wireMockRule1.addStubMapping(
-                stubFor(
-                        post(urlEqualTo("/geostore/users/create"))
-                                .withRequestBody(equalToXml(requestBody))
-                                .willReturn(
-                                        aResponse()
-                                                .withStatus(201)
-                                                .withHeader("Content-Type", "text/xml")
-                                                .withBody("<response>5</response>"))));
+        wireMockRule1.stubFor(
+                post(urlEqualTo("/geostore/users/create"))
+                        .withRequestBody(equalToXml(requestBody))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(201)
+                                        .withHeader("Content-Type", "text/xml")
+                                        .withBody("<response>5</response>")));
 
-        String url = "http://localhost:" + wireMockRule1.port() + "/geostore/users/create";
+        String url = "http://localhost:" + wireMockRule1.getPort() + "/geostore/users/create";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
         HttpPost httpPost = new HttpPost(proxyURL);
         StringEntity stringEntity = new StringEntity(requestBody);
@@ -147,8 +138,8 @@ public class HttpProxyIntegrationTests {
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpResponse httpResponse = httpClient.execute(httpPost);
-            Assert.assertEquals("text/xml", httpResponse.getFirstHeader("Content-Type").getValue());
-            Assert.assertEquals(201, httpResponse.getStatusLine().getStatusCode());
+            Assertions.assertEquals("text/xml", httpResponse.getFirstHeader("Content-Type").getValue());
+            Assertions.assertEquals(201, httpResponse.getStatusLine().getStatusCode());
             wireMockRule1.verify(postRequestedFor(urlEqualTo("/geostore/users/create")));
         }
     }
@@ -165,19 +156,18 @@ public class HttpProxyIntegrationTests {
                 "    \"userName\": \"Jane Doe\"\n" +
                 "  }\n" +
                 "}";
-        wireMockRule1.addStubMapping(
-                stubFor(
-                        post(urlEqualTo("/geostore/users/create"))
-                                .withRequestBody(equalToJson(requestBody))
-                                .willReturn(
-                                        aResponse()
-                                                .withStatus(201)
-                                                .withHeader("Content-Type", "application/json")
-                                                .withBody("{\n" +
-                                                        "  \"response\": 5\n" +
-                                                        "}"))));
+        wireMockRule1.stubFor(
+                post(urlEqualTo("/geostore/users/create"))
+                        .withRequestBody(equalToJson(requestBody))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(201)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody("{\n" +
+                                                "  \"response\": 5\n" +
+                                                "}")));
 
-        String url = "http://localhost:" + wireMockRule1.port() + "/geostore/users/create";
+        String url = "http://localhost:" + wireMockRule1.getPort() + "/geostore/users/create";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
         HttpPost httpPost = new HttpPost(proxyURL);
         StringEntity stringEntity = new StringEntity(requestBody);
@@ -185,8 +175,8 @@ public class HttpProxyIntegrationTests {
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpResponse httpResponse = httpClient.execute(httpPost);
-            Assert.assertEquals("application/json", httpResponse.getFirstHeader("Content-Type").getValue());
-            Assert.assertEquals(201, httpResponse.getStatusLine().getStatusCode());
+            Assertions.assertEquals("application/json", httpResponse.getFirstHeader("Content-Type").getValue());
+            Assertions.assertEquals(201, httpResponse.getStatusLine().getStatusCode());
             wireMockRule1.verify(postRequestedFor(urlEqualTo("/geostore/users/create")));
         }
     }
@@ -198,17 +188,16 @@ public class HttpProxyIntegrationTests {
     public void testPUTUsingWireMock() throws IOException {
 
         String requestBody = "<user><userId>5</userId><userName>John Doe</userName></user>";
-        wireMockRule.addStubMapping(
-                stubFor(
-                        put(urlEqualTo("/geostore/users/5"))
-                                .withRequestBody(equalToXml(requestBody))
-                                .willReturn(
-                                        aResponse()
-                                                .withStatus(200)
-                                                .withHeader("Content-Type", "text/xml")
-                                                .withBody("<response>5</response>"))));
+        wireMockRule.stubFor(
+                put(urlEqualTo("/geostore/users/5"))
+                        .withRequestBody(equalToXml(requestBody))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "text/xml")
+                                        .withBody("<response>5</response>")));
 
-        String url = "http://localhost:" + wireMockRule.port() + "/geostore/users/5";
+        String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/users/5";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
         HttpPut httpPut = new HttpPut(proxyURL);
         StringEntity stringEntity = new StringEntity(requestBody);
@@ -216,7 +205,7 @@ public class HttpProxyIntegrationTests {
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpResponse httpResponse = httpClient.execute(httpPut);
-            Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+            Assertions.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
             wireMockRule.verify(putRequestedFor(urlEqualTo("/geostore/users/5")));
         }
     }
@@ -231,19 +220,18 @@ public class HttpProxyIntegrationTests {
         System.setProperty("http.proxyHost", "");
         System.setProperty("http.proxyPort", "");
 
-        wireMockRule.addStubMapping(
-                stubFor(
-                        get(urlEqualTo("/geostore/resources"))
-                                .willReturn(
-                                        aResponse()
-                                                .withStatus(200))));
+        wireMockRule.stubFor(
+                get(urlEqualTo("/geostore/resources"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)));
 
-        String url = "http://localhost:" + wireMockRule.port() + "/geostore/resources";
+        String url = "http://localhost:" + wireMockRule.getPort() + "/geostore/resources";
         String proxyURL = "http://localhost:" + localPort + "/http_proxy/proxy?url=" + url;
         HttpGet httpGet = new HttpGet(proxyURL);
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpResponse httpResponse = httpClient.execute(httpGet);
-            Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+            Assertions.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
             wireMockRule.verify(getRequestedFor(urlEqualTo("/geostore/resources")));
         }
     }
@@ -255,10 +243,10 @@ public class HttpProxyIntegrationTests {
     public void testHttpDefaultPort() throws IOException {
         String urlStr = "http://localhost/geoserver/wms?service=wms%26version=1.3.0&request=GetCapabilities";
         URL url = Utils.buildURL(urlStr);
-        Assert.assertEquals(url.getPort(), Utils.DEFAULT_HTTP_PORT);
-        Assert.assertEquals(url.getProtocol(), "http");
-        Assert.assertEquals(url.getHost(), "localhost");
-        Assert.assertEquals(url.getFile(), "/geoserver/wms?service=wms%26version=1.3.0&request=GetCapabilities");
+        Assertions.assertEquals(url.getPort(), Utils.DEFAULT_HTTP_PORT);
+        Assertions.assertEquals(url.getProtocol(), "http");
+        Assertions.assertEquals(url.getHost(), "localhost");
+        Assertions.assertEquals(url.getFile(), "/geoserver/wms?service=wms%26version=1.3.0&request=GetCapabilities");
     }
 
     /**
@@ -268,14 +256,14 @@ public class HttpProxyIntegrationTests {
     public void testHttpsDefaultPort() throws IOException {
         String urlStr = "https://georchestra.geo-solutions.it/geoserver/wms?service=WMS%26version=1.3.0&request=GetCapabilities";
         URL url = Utils.buildURL(urlStr);
-        Assert.assertEquals(url.getPort(), Utils.DEFAULT_HTTPS_PORT);
-        Assert.assertEquals(url.getProtocol(), "https");
-        Assert.assertEquals(url.getHost(), "georchestra.geo-solutions.it");
-        Assert.assertEquals(url.getFile(), "/geoserver/wms?service=WMS%26version=1.3.0&request=GetCapabilities");
+        Assertions.assertEquals(url.getPort(), Utils.DEFAULT_HTTPS_PORT);
+        Assertions.assertEquals(url.getProtocol(), "https");
+        Assertions.assertEquals(url.getHost(), "georchestra.geo-solutions.it");
+        Assertions.assertEquals(url.getFile(), "/geoserver/wms?service=WMS%26version=1.3.0&request=GetCapabilities");
     }
 
 
-    @AfterClass
+    @AfterAll
     public static void stopServer() {
         try {
 

--- a/src/test/java/it/geosolutions/httpproxy/HttpProxyTest.java
+++ b/src/test/java/it/geosolutions/httpproxy/HttpProxyTest.java
@@ -29,11 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -44,28 +44,29 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
 
 /**
  * HttpProxyTest class. Test Cases for the HTTPProxy servlet.
  *
  * @author Lorenzo Natali at lorenzo.natali@geo-solutions.it
  */
-public class HttpProxyTest extends Mockito {
+public class HttpProxyTest {
 
     final ServletConfig servletConfig = mock(ServletConfig.class);
     ServletContext ctx = mock(ServletContext.class);
-    Map<String, String[]> parameters = new HashMap<String, String[]>();
-    private List<Header> headers = new ArrayList<Header>();
+    Map<String, String[]> parameters = new HashMap<>();
+    private List<String> headers = new ArrayList<>();
 
     org.apache.http.client.HttpClient mockHttpClient;
     HTTPProxy proxy;
     String fakeLocation;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         File f = new File(getClass().getClassLoader()
                 .getResource("test-proxy.properties").getFile());
@@ -123,8 +124,8 @@ public class HttpProxyTest extends Mockito {
                 "http://proxy.com/http-proxy/proxy?url="
                         + URLEncoder.encode(fakeLocation, "UTF-8"));
         final byte[] data = servletOutputStream.baos.toByteArray();
-        Assert.assertNotNull(data);
-        Assert.assertTrue(data.length == 0);
+        Assertions.assertNotNull(data);
+        Assertions.assertTrue(data.length == 0);
     }
 
     @Test
@@ -159,7 +160,7 @@ public class HttpProxyTest extends Mockito {
         when(postRequest.getQueryString()).thenReturn("url=https://jsonplaceholder.typicode.com/test/createUser");
         when(postRequest.getMethod()).thenReturn("post");
 
-        Enumeration<Object> enumeration = Collections.enumeration(Collections.emptyList());
+        Enumeration<String> enumeration = Collections.enumeration(Collections.emptyList());
         when(postRequest.getHeaderNames()).thenReturn(enumeration);
 
         ServletInputStream stream = mock(ServletInputStream.class);
@@ -173,8 +174,8 @@ public class HttpProxyTest extends Mockito {
         proxy.doPost(postRequest, getResponse);
         verify(getResponse).setStatus(200);
         final byte[] data = servletOutputStream.baos.toByteArray();
-        Assert.assertNotNull(data);
-        Assert.assertTrue(data.length != 0);
+        Assertions.assertNotNull(data);
+        Assertions.assertTrue(data.length != 0);
     }
 
 }

--- a/src/test/java/it/geosolutions/httpproxy/RequestHeaderFilterTest.java
+++ b/src/test/java/it/geosolutions/httpproxy/RequestHeaderFilterTest.java
@@ -28,10 +28,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -40,23 +40,19 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.entity.StringEntity;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
 /**
  * Tests for request header whitelist and blacklist filtering.
  */
-public class RequestHeaderFilterTest extends Mockito {
+public class RequestHeaderFilterTest {
 
     Map<String, String[]> parameters = new HashMap<>();
-    private List<Header> headers = new ArrayList<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // URL must match one of the reqtypeWhitelist patterns in proxy.properties
         parameters.put("url", new String[]{"http://sample.com/csw"});

--- a/src/test/java/it/geosolutions/httpproxy/StubServletOutputStream.java
+++ b/src/test/java/it/geosolutions/httpproxy/StubServletOutputStream.java
@@ -3,11 +3,17 @@ package it.geosolutions.httpproxy;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import javax.servlet.ServletOutputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 
 public class StubServletOutputStream extends ServletOutputStream {
  public ByteArrayOutputStream baos = new ByteArrayOutputStream();
    public void write(int i) throws IOException {
     baos.write(i);
+ }
+   public boolean isReady() {
+    return true;
+ }
+   public void setWriteListener(WriteListener writeListener) {
  }
 }

--- a/src/test/java/it/geosolutions/httpproxy/jetty/Start.java
+++ b/src/test/java/it/geosolutions/httpproxy/jetty/Start.java
@@ -19,24 +19,20 @@
  */
 package it.geosolutions.httpproxy.jetty;
 
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.mortbay.jetty.Connector;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.webapp.WebAppContext;
-import org.mortbay.thread.BoundedThreadPool;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Start class for test using JETTY server.
+ * Start class for test using embedded Jetty server.
  * 
  * @author Tobia di Pisa at tobia.dipisa@geo-solutions.it
  */
 public class Start {
 
-    private final static Logger LOGGER = Logger.getLogger(Start.class.toString());
+    private static final Logger LOGGER = LoggerFactory.getLogger(Start.class);
 
     /**
      * @param args
@@ -47,16 +43,7 @@ public class Start {
         try {
             jettyServer = new Server();
 
-            // /////////////////////////////////////////////////////
-            // Don't even think of serving more than XX requests
-            // in parallel... we have a limit in our processing
-            // and memory capacities.
-            // /////////////////////////////////////////////////////
-
-            BoundedThreadPool tp = new BoundedThreadPool();
-            tp.setMaxThreads(50);
-
-            SocketConnector conn = new SocketConnector();
+            ServerConnector connector = new ServerConnector(jettyServer);
             String portVariable = System.getProperty("jetty.port");
             int port = parsePort(portVariable);
 
@@ -64,37 +51,27 @@ public class Start {
                 port = 8080;
             }
 
-            conn.setPort(port);
-            conn.setThreadPool(tp);
-            conn.setAcceptQueueSize(100);
-            jettyServer.setConnectors(new Connector[] { conn });
+            connector.setPort(port);
+            jettyServer.addConnector(connector);
 
-            WebAppContext wah = new WebAppContext();
-            wah.setContextPath("/http_proxy");
-            wah.setWar("src/main/webapp");
-            jettyServer.setHandler(wah);
-            wah.setTempDirectory(new File("target/work"));
+            WebAppContext webapp = new WebAppContext();
+            webapp.setContextPath("/http_proxy");
+            webapp.setWar("src/main/webapp");
+            webapp.setTempDirectory(new java.io.File("target/work"));
+            jettyServer.setHandler(webapp);
 
             jettyServer.start();
-
-            // ////////////////////////////////////////////////////////////////////////
-            // Use this to test normal stop behavior, that is, to check stuff that
-            // need to be done on container shutdown (and yes, this will make
-            // jetty stop just after you started it...)
-            // jettyServer.stop();
-            // ////////////////////////////////////////////////////////////////////////
+            LOGGER.info("Jetty started on port {}", port);
+            jettyServer.join();
 
         } catch (Exception e) {
-            if (LOGGER.isLoggable(Level.SEVERE))
-                LOGGER.log(Level.SEVERE, "Could not start the Jetty server: " + e.getMessage(), e);
+            LOGGER.error("Could not start the Jetty server: " + e.getMessage(), e);
 
             if (jettyServer != null) {
                 try {
                     jettyServer.stop();
                 } catch (Exception e1) {
-                    if (LOGGER.isLoggable(Level.SEVERE))
-                        LOGGER.log(Level.SEVERE,
-                                "Unable to stop the " + "Jetty server:" + e1.getMessage(), e1);
+                    LOGGER.error("Unable to stop the Jetty server: " + e1.getMessage(), e1);
                 }
             }
         }
@@ -110,7 +87,7 @@ public class Start {
         }
 
         try {
-            return Integer.valueOf(portVariable).intValue();
+            return Integer.parseInt(portVariable);
         } catch (NumberFormatException e) {
             return -1;
         }


### PR DESCRIPTION
This PR: 

- Bumps Java from 8 to 21 and use Jakarta instead of javax
- Add a main entrypoint
- Create a docker image with to allow a standalone http-proxy

CI is failing cause of java version use in repo's workflow. We could also set java 17 for minimal version