### PR TITLE
Bumped commons-fileupload to 1.6.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.5</version>
+				<version>1.6.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Bumps commons-fileupload to 1.5 to 1.6.0 to avoid vulnerabilities.