### PR TITLE
build: add support for ssh key for publishing artifacts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,12 @@ jobs:
     concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.HTTP_PROXY_MAVEN_SSH_KEY }}
+      - name: Trust Maven Host
+        run: ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
@@ -42,14 +48,8 @@ jobs:
           distribution: 'adopt'
           server-id: geosolutions
           server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
       - name: Publish package
         run: |
-          # Setup SSH keys for SFTP
-          mkdir -p ~/.ssh
-          # add geo-solutions.it to known hosts to avoid prompts
-          ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
           mvn -B clean install deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.GS_MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.HTTP_PROXY_MAVEN_USERNAME }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.HTTP_PROXY_MAVEN_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GS_MAVEN_HTTPPROXY_KEY }}
       - name: Trust Maven Host
         run: ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
       - name: Set up Maven Central Repository
@@ -52,4 +52,4 @@ jobs:
         run: |
           mvn -B clean install deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.HTTP_PROXY_MAVEN_USERNAME }}
+          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_HTTPPROXY_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <repository>
         <uniqueVersion>false</uniqueVersion>
         <id>geosolutions</id>
-        <url>sftp://maven.geo-solutions.it</url>
+        <url>scpexe://maven.geo-solutions.it</url>
       </repository>
     </distributionManagement>
 
@@ -147,7 +147,7 @@
 		<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ssh</artifactId>
+				<artifactId>wagon-ssh-external</artifactId>
 				<version>3.5.3</version>
 			</extension>
 		</extensions>


### PR DESCRIPTION
# Description
Adds support for ssh keys authentication in github actions to push to maven.geo-solutions.it repository.

Needs new secrets:
- `GS_MAVEN_HTTPPROXY_USERNAME`
- `GS_MAVEN_HTTPPROXY_KEY`

## Rollback
Rollback would include reverting the PR, that should enable existing `user/password based` workflow. As a precaution existing secrets are left intact and to be deleted only when ssh-key based workflow is working.

Existing secrets INTACT.
```
GS_MAVEN_USERNAME
GS_MAVEN_PASSWORD
```