### PR TITLE
Fix release deploy: add ssh-keyscan for known_hosts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,10 @@ jobs:
         server-password: MAVEN_PASSWORD
 
     - name: Publish package
-      run: mvn clean install deploy
+      run: |
+        mkdir -p ~/.ssh
+        ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
+        mvn clean install deploy
       env:
         MAVEN_USERNAME: ${{ secrets.GS_MAVEN_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.GS_MAVEN_PASSWORD }}


### PR DESCRIPTION
## Problema
Workflow `Release` (`release.yml`, job `fix-version`) esegue `mvn clean install deploy` senza popolare `~/.ssh/known_hosts`. Il deploy usa `wagon-ssh` (JSch, `sftp://maven.geo-solutions.it`), quindi la host key viene rifiutata:

```
reject HostKey: maven.geo-solutions.it
```

Run fallito: https://github.com/geosolutions-it/http-proxy/actions/runs/29906020244

## Causa
`CI.yml` (job `publish`) ha lo step `ssh-keyscan`, `release.yml` no. Il deploy non e mai esercitato dai PR (il job `build` fa solo `install`), quindi la divergenza e emersa solo al dispatch della release 1.6.0.

## Fix
Aggiunto lo step `ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts` prima del deploy, in parita con `CI.yml`.